### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 🔥🔥🔥 A paper list of some recent  works about Token Compress for Vit and VLM.
 ## VLM
 ### 2024
+
+-  <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2409.03206-red?logo=arxiv" height="14" />  [TC-LLaVA: Rethinking the Transfer from Image to Video Understanding with Temporal Consideration](https://arxiv.org/pdf/2409.03206) .[TC-LLaVA;Video;]
+
+
 -  <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2411.03312-red?logo=arxiv" height="14" />  [Inference Optimal VLMs Need Only One Visual Token but Larger Models](https://arxiv.org/pdf/2411.03312) .[QueCC;[Github](https://github.com/locuslab/llava-token-compression)]
 -  <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2410.23782-red?logo=arxiv" height="14" />  [Video Token Merging for Long-form Video Understandin](https://arxiv.org/pdf/2410.23782) .[Learnable VTM;Video]
 -  <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2410.17434-red?logo=arxiv" height="14" />  [LongVU: Spatiotemporal Adaptive Compression for Long Video-Language Understanding](https://arxiv.org/pdf/2410.17434) .[LongVU;Video;[Github](https://github.com/Vision-CAIR/LongVU)]


### PR DESCRIPTION
重新思考从图像到视频理解的迁移，并考虑时间因素

将图像预训练的 MLLMs 适应于与视频相关的任务。 

在本文中，我们提出了两种策略，通过改进 LLMs 中的层间注意力计算来增强模型在视频理解任务中的能力。 具体而言，第一种方法侧重于使用时间感知双 RoPE 来增强旋转位置嵌入 (RoPE)，它引入了时间位置信息以增强 MLLM 的时间建模能力，同时保留视觉和文本符元的相对位置关系。 第二种方法涉及使用帧级块因果注意力掩码来增强注意力掩码，这是一种简单而有效的方法，它扩展了视频帧内和跨帧的视觉符元交互，同时保持因果推理机制。 基于这些提出的方法，我们将 LLaVA 调整为视频理解任务，将其命名为时间考虑的 LLaVA (TC-LLaVA)。 我们的 TC-LLaVA 在各种视频理解基准测试中取得了新的最先进的性能，仅在与视频相关的 datasets 上进行监督微调 (SFT)。